### PR TITLE
Update ASJTag.m

### DIFF
--- a/ASJTagsView/ASJTag.m
+++ b/ASJTagsView/ASJTag.m
@@ -108,8 +108,6 @@
   if (!tagFont) {
     return;
   }
-  _tagFont = tagFont;
-  _tagButton.titleLabel.font = tagFont;
 }
 
 @end


### PR DESCRIPTION
- (void)setTagFont:(UIFont *)tagFont
{
  if (!tagFont) {
    return;
  }
    _tagFont = tagFont;
    _tagButton.titleLabel.font = tagFont;
}

   _tagButton.titleLabel.font = tagFont is leading to -[NSISLinearExpression pointSize]: unrecognized selector sent to instance exception. Apparently, removing these lines solved that issue. I'd also check if setTagFont is really necessary after initialization.